### PR TITLE
Fix inline-style-prefixer import

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -3,7 +3,7 @@
  * Let's not forget that
  */
 
-import prefix from 'inline-style-prefixer/static';
+import { prefix } from 'inline-style-prefixer';
 import isUnitlessNumber from './isUnitlessNumber';
 import kebabifyStyleName from './kebabifyStyleName';
 


### PR DESCRIPTION
Proper way to import `prefix` in the newer versions of `inline-style-prefixer` is `import { prefix } from 'inline-style-prefixer'`. I noticed this error when I tried to use your `react-modal-dialog` package.